### PR TITLE
視線制御のクリップ名を自動で変更するかを設定する機能を追加

### DIFF
--- a/Editor/Core/Process/LookAt/LookAtStatusDrawer.cs
+++ b/Editor/Core/Process/LookAt/LookAtStatusDrawer.cs
@@ -11,6 +11,8 @@ namespace UniEyeController.Editor.Core.Process.LookAt
 {
     public class LookAtStatusDrawer : EyeStatusDrawerBase
     {
+        private SerializedProperty _autoRenameClipName;
+        
         private SerializedProperty _weight;
         private SerializedProperty _method;
         private SerializedProperty _targetTransform;
@@ -22,6 +24,8 @@ namespace UniEyeController.Editor.Core.Process.LookAt
         
         public LookAtStatusDrawer(SerializedProperty property) : base(property)
         {
+            _autoRenameClipName = property.FindPropertyRelative(nameof(LookAtStatus.autoRenameClipName));
+            
             _weight = property.FindPropertyRelative(nameof(LookAtStatus.weight));
             _method = property.FindPropertyRelative(nameof(LookAtStatus.method));
             _targetTransform = property.FindPropertyRelative(nameof(LookAtStatus.targetTransform));
@@ -35,6 +39,9 @@ namespace UniEyeController.Editor.Core.Process.LookAt
         public override void Draw(bool isTimeline)
         {
             base.Draw(isTimeline);
+            
+            EditorGUILayout.PropertyField(_autoRenameClipName, new GUIContent("クリップ名を自動で変更"));
+            EditorGUILayout.Space();
             
             EditorGUILayout.PropertyField(_weight, new GUIContent("適用度"));
             EditorGUILayout.Space();

--- a/Editor/Timeline/LookAt/UniEyeLookAtClipEditor.cs
+++ b/Editor/Timeline/LookAt/UniEyeLookAtClipEditor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UniEyeController.Core.Process.LookAt;
 using UniEyeController.Core.Process.LookAt.Constants;
 using UniEyeController.Timeline.LookAt;
 using UnityEditor.Timeline;
@@ -37,7 +36,11 @@ namespace UniEyeController.Editor.Timeline.LookAt
                     throw new ArgumentOutOfRangeException();
             }
 
-            clip.displayName = asset.status.ToString();
+            if (asset.status.autoRenameClipName)
+            {
+                clip.displayName = asset.status.ToString();
+            }
+            
             options.errorText = asset.status.ErrorMessage;
             options.highlightColor = color;
             return options;

--- a/Runtime/Core/Process/LookAt/LookAtStatus.cs
+++ b/Runtime/Core/Process/LookAt/LookAtStatus.cs
@@ -23,6 +23,8 @@ namespace UniEyeController.Core.Process.LookAt
         [Range(-1f, 1f)]
         public float normalizedPitch;
 
+        public bool autoRenameClipName;
+
         public static LookAtStatus Default
         {
             get
@@ -31,6 +33,7 @@ namespace UniEyeController.Core.Process.LookAt
                 status.method = LookAtMethod.Direction;
                 status.direction = LookAtDirection.Forward;
                 status.weight = 1f;
+                status.autoRenameClipName = true;
                 return status;
             }
         }


### PR DESCRIPTION
「クリップ名を自動で変更」を追加
![image](https://github.com/mkc1370/UniEyeController/assets/40651807/4e629c6b-6cb8-4213-9466-67667887681c)