### PR TITLE
LookAtTrackのブレンド対応

### DIFF
--- a/Runtime/Core/Process/LookAt/LookAtProcess.cs
+++ b/Runtime/Core/Process/LookAt/LookAtProcess.cs
@@ -46,7 +46,7 @@ namespace UniEyeController.Core.Process.LookAt
                     if (lookAtStatus.targetTransform == null)
                     {
                         Debug.LogError($"Target Transform is not set.");
-                        EyeController.Rotate(Vector2.zero, weight, RotationApplyMethod.Direct);
+                        EyeController.Rotate(Vector2.zero, weight, rotationApplyMethod);
                         return;
                     }
 
@@ -57,7 +57,7 @@ namespace UniEyeController.Core.Process.LookAt
                     if (mainCamera == null)
                     {
                         Debug.LogError($"MainCamera is not found.");
-                        EyeController.Rotate(Vector2.zero, weight, RotationApplyMethod.Direct);
+                        EyeController.Rotate(Vector2.zero, weight, rotationApplyMethod);
                         return;
                     }
 

--- a/Runtime/Core/Process/LookAt/LookAtProcess.cs
+++ b/Runtime/Core/Process/LookAt/LookAtProcess.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UniEyeController.Constants;
 using UniEyeController.Core.Controller.Eye.Constants;
 using UniEyeController.Core.Process.Core;
 using UniEyeController.Core.Process.LookAt.Constants;
@@ -19,6 +20,7 @@ namespace UniEyeController.Core.Process.LookAt
         public LookAtProcess()
         {
             status = LookAtStatus.Default;
+            updateMethod = UpdateMethod.Update;
         }
         
         public void ResetEyeRotation()

--- a/Runtime/Timeline/LookAt/UniEyeLookAtMixer.cs
+++ b/Runtime/Timeline/LookAt/UniEyeLookAtMixer.cs
@@ -51,6 +51,7 @@ namespace UniEyeController.Timeline.LookAt
 
             _process.status = _statusCache.Value;
 
+            var nonZeroClipCount = 0;
             for (var i = 0; i < Clips.Length; i++)
             {
                 var clip = Clips[i];
@@ -66,13 +67,22 @@ namespace UniEyeController.Timeline.LookAt
                     var status = asset.status;
                     status.weight *= weight;
 
-                    _process.status = status;
-                    // TODO : ブレンドに対応させる
-                    break;
+                    if (nonZeroClipCount == 0)
+                    {
+                        _process.status = status;
+                    }
+                    else if (nonZeroClipCount == 1)
+                    {
+                        _process.status2 = status;
+                        _process.useStatus2 = true;
+                    }
+
+                    nonZeroClipCount++;
                 }
             }
 
             _process.Progress(UpdateMethod.Timeline);
+            _process.useStatus2 = false;
         }
     }
 }


### PR DESCRIPTION
## 概要
LookAtTrackの2個のクリップのブレンドに対応

## その他
LookAtProcessがLateUpdateの場合、タイムラインからの視線制御が上書きされてしまうのでデフォルトでUpdateになるように変更

Close #51 