### PR TITLE
TransformとAnimatorだけのキャラクターが生成されたままになるバグを修正

### DIFF
--- a/Runtime/Core/Controller/Eye/DoubleEyeDefaultStatus.cs
+++ b/Runtime/Core/Controller/Eye/DoubleEyeDefaultStatus.cs
@@ -26,6 +26,12 @@ namespace UniEyeController.Core.Controller.Eye
                 Debug.LogError("AnimatorがHumanoidではありません");
                 return null;
             }
+            
+            if(!animator.GetBoneTransform(HumanBodyBones.LeftEye) || !animator.GetBoneTransform(HumanBodyBones.RightEye))
+            {
+                Debug.LogError("Animatorに目のボーンが設定されていません");
+                return null;
+            }
 
             var clonedParent = CreateTransformTreeClone(animator.transform);
             var clonedAnimator = clonedParent.gameObject.AddComponent<Animator>();


### PR DESCRIPTION
途中で例外を吐いて、TransformとAnimatorだけのキャラクターが生成されたままになるバグがあった
目のボーンの有無のチェックを追加して対応